### PR TITLE
Three fixes 

### DIFF
--- a/models/CalendarEntry.php
+++ b/models/CalendarEntry.php
@@ -53,10 +53,6 @@ class CalendarEntry extends ContentActiveRecord implements \humhub\modules\searc
     public $start_time;
     public $end_time;
 
-    /**
-     * Default participiation Mode
-     */
-    public $participation_mode = 2;
 
     /**
      * Participation Modes
@@ -73,6 +69,16 @@ class CalendarEntry extends ContentActiveRecord implements \humhub\modules\searc
     const FILTER_NOT_RESPONDED = 3;
     const FILTER_RESPONDED = 4;
     const FILTER_MINE = 5;
+
+    public function init()
+    {
+        parent::init();
+
+        /**
+        * Default participiation Mode
+        */
+        $this->participation_mode = 2;
+    }
 
     /**
      * @inheritdoc

--- a/views/global/index.php
+++ b/views/global/index.php
@@ -17,7 +17,7 @@ use yii\helpers\Url;
                         'selectors' => $selectors,
                         'filters' => $filters,
                         'loadUrl' => Url::to(['load-ajax']),
-                        'createUrl' => $user->createUrl('/calendar/entry/edit', array('start_time' => '-start-', 'end_time' => '-end-', 'fullCalendar' => '1', 'createFromGlobalCalendar' => 1)),
+                        'createUrl' => $user->createUrl('/calendar/entry/edit', array('start_datetime' => '-start-', 'end_datetime' => '-end-', 'fullCalendar' => '1', 'createFromGlobalCalendar' => 1)),
                     ));
                     ?>
 


### PR DESCRIPTION
I've fixed three problems that I have using this module:
* In main calendar page, event creation modal dialog doesn't show selected date. The problem is the name of the GET parameters (start_time instead of start_datetime and end_time of end_datetime). 
*  CalendarEntry's participation mode default value always override database value. I removed the variable declaration, set the participation mode default value in a new init function and it works.
* My mother tongue isn't English, as you probably guessed :). Dates in Spanish uses the format dd/mm/yyyy, but the DateTime class constructor can't parse it properly. So, I've used the formatter's dateFormat to guess user format and used in \DateTime::createFromFormat function. I think this could be done better, but at least works when the dateFormat is a php format.

Sorry that I send these three fixed together, I didn't realise that GitHub doesn't allows to choose commits to create a PR.