### PR TITLE
FIX Undecode double quotes from json ajax response

### DIFF
--- a/resources/js/fullcalendar/fullcalendar.js
+++ b/resources/js/fullcalendar/fullcalendar.js
@@ -6955,10 +6955,14 @@ DayGrid.mixin({
 				timeHtml = '<span class="fc-time">' + htmlEscape(timeText) + '</span>';
 			}
 		}
-
+		var parser = new DOMParser;
+		var dom = parser.parseFromString(
+		    '<!doctype html><body>' + event.title,
+		    'text/html');
+		var decodeTitle = dom.body.textContent;
 		titleHtml =
 			'<span class="fc-title">' +
-				(htmlEscape(event.title || '') || '&nbsp;') + // we always want one line of height
+				(htmlEscape(decodeTitle || '') || '&nbsp;') + // we always want one line of height
 			'</span>';
 		
 		return '<a class="' + classes.join(' ') + '"' +


### PR DESCRIPTION
When you start an ajax request to retrieve a list of events in a month, prevent double scape htmlentities