### PR TITLE
Cleanup: remove optional part of parameter

### DIFF
--- a/models/CalendarEntry.php
+++ b/models/CalendarEntry.php
@@ -547,13 +547,9 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, CalendarI
         return $this->formatter->getOffsetDays();
     }
 
-    public function getParticipantCount($state = null)
+    public function getParticipantCount($state)
     {
-        if($state) {
-            return $this->getParticipants()->where(['participation_state' => $state])->count();
-        } else {
-            return $this->getParticipants()->count();
-        }
+        return $this->getParticipants()->where(['participation_state' => $state])->count();
     }
 
     /**


### PR DESCRIPTION
getParticipantCount without an explicit state could be misleading: who
exactly are we counting?

We'd be counting any user with a ParticipantStatus associated with
that event. That includes both `declined` and `accepted` statuses. A
count on the combination of this is rarely useful.

Luckily, getParticipantCount is always called with this state
parameter specified. Let's remove the optional part for clarity.