### PR TITLE
Fix calendar interface and widget issues

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -66,7 +66,9 @@ class Events extends \yii\base\Object
         $settings = SnippetModuleSettings::instantiate();
 
         if ($space->isModuleEnabled('calendar')) {
-            $event->sender->addWidget(UpcomingEvents::className(), ['contentContainer' => $space], ['sortOrder' => $settings->upcomingEventsSnippetSortOrder]);
+            if ($settings->showUpcomingEventsSnippet()) {
+                $event->sender->addWidget(UpcomingEvents::className(), ['contentContainer' => $space], ['sortOrder' => $settings->upcomingEventsSnippetSortOrder]);
+            }
         }
     }
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -69,11 +69,27 @@ Items are appended by means of `$event->addItems($itemTypeKey, $itemsArray)`. Th
 
  - `start`: DateTime instance of the start time ideally with timezone (otherwise we assume app timezone).
  - `end`: DateTime instance of the end time ideally with timezone (otherwise we assume app timezone).
+ - `allDay`: Boolean whether or not the events are all-day events.
  - `title`: The title of the given item, displayed in the calendar and snippet
  - `editable`: Whether or not this item is editable (resize/drag/drop) this will also require the updateUrl
  - `viewUrl`: This link will be loaded into a modal once the item is selected in the calendar
  - `openUrl`: A link to the actual content (e.g Permalink) used in the snippet
  - `updateUrl`: A url used to directly update the start/end time in case `editable` is set to true
+
+> Note: If you want to add full-day events, you must add a day to the end date and set the time to 00:00:00. 
+The following example demonstrates this:
+
+```php
+// Example 1: We want to add an one-day all-day event: 01.01.2018
+$start = new DateTime('2018-01-01 00:00:00')
+$end = new DateTime('2018-01-02 00:00:00')  // one day longer, but time set to 00:00:00!
+```
+
+```php
+// Example 2: We want to add a two-day all-day event: 01.01.2018 - 02.01.2018
+$start = new DateTime('2018-01-01 00:00:00')
+$end = new DateTime('2018-01-03 00:00:00')  // one day longer, but time set to 00:00:00!
+```
 
 **Event.php:**
 

--- a/interfaces/CalendarService.php
+++ b/interfaces/CalendarService.php
@@ -22,6 +22,7 @@ use humhub\modules\calendar\models\CalendarEntryQuery;
 use humhub\modules\content\components\ActiveQueryContent;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 use yii\base\Component;
+use yii\helpers\ArrayHelper;
 
 /**
  * This service component supports integration functionality and is responsible for retrieving
@@ -116,6 +117,9 @@ class CalendarService extends Component
         $calendarEntries = CalendarEntryQuery::findForFilter($start, $end, $contentContainer, $filters, $limit);
 
         $result = array_merge($calendarEntries, $result);
+
+        // sort external entries
+        ArrayHelper::multisort($result, ['startDateTime', 'endDateTime'], [SORT_ASC, SORT_ASC]);
 
         return (count($result) > $limit) ? array_slice($result, 0, $limit) : $result;
     }

--- a/models/CalendarDateFormatter.php
+++ b/models/CalendarDateFormatter.php
@@ -131,7 +131,14 @@ class CalendarDateFormatter extends Object
 
     public function getDurationDays()
     {
-        $interval = $this->calendarItem->getStartDateTime()->diff($this->calendarItem->getEndDateTime(), true);
+        $end = $this->calendarItem->getEndDateTime();
+        if ($this->calendarItem->isAllDay()) {
+            if ($end === $this->calendarItem->getEndDateTime()->setTime('00', '00', '00'))
+                $end->modify('-1 day'); // revert modifications for all-day events integrated via interface
+        }
+
+        $interval = $this->calendarItem->getStartDateTime()->diff($end, true);
+
         return $interval->days + 1;
     }
 


### PR DESCRIPTION
This fixes three issues:

1. Issue https://github.com/humhub/humhub-modules-calendar/issues/103 and https://github.com/humhub/humhub-modules-calendar/issues/108
Fixed the display of all-day events in the calendar view and widget. For this purpose, an entry has been added to the interface documentation that describes how to pass all-day events to the interface.

**Before:**
<img width="536" alt="before-interface-fix" src="https://user-images.githubusercontent.com/8705799/37253507-dab095f2-2532-11e8-81f9-65bd81115567.png"> 
**Afterwards:**
 <img width="536" alt="after-interface-fix" src="https://user-images.githubusercontent.com/8705799/37253509-e8462fa6-2532-11e8-8d04-a27513a50b33.png">

___

2. Issue https://github.com/humhub/humhub-modules-calendar/issues/119
Fixed sorting issue for events integrated via interface:

**Before:**
<img width="536" alt="before-sorting-fix" src="https://user-images.githubusercontent.com/8705799/37253527-403666fe-2533-11e8-8e27-04662f15cebc.png"> 
**Afterwards:**
<img width="536" alt="after-sorting-fix" src="https://user-images.githubusercontent.com/8705799/37253529-4a067296-2533-11e8-939f-e4d217fda073.png">

___

3. Issue https://github.com/humhub/humhub-modules-calendar/issues/107
Fixed: Disabling upcoming events snippet also in spaces