### PR TITLE
Enable Travis-CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ install:
   - /bin/sh .travis/setup-humhub.sh
 
 script:
+  - php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &>/dev/null &
+  - sleep 5
+  - curl --fail --head http://127.0.0.1:8080/index-test.php
   - cd tests
   - php ${HUMHUB_PATH}/protected/vendor/bin/codecept build
   - php ${HUMHUB_PATH}/protected/vendor/bin/codecept run

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 
 env:
   global:
-    - HUMHUB_PATU=/opt/humhub
+    - HUMHUB_PATH=/opt/humhub
 #  matrix:
 #    - HUMHUB_VERSION=master
 #    - HUMHUB_VERSION=v1.3-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,22 +18,24 @@ php:
 env:
   global:
     - HUMHUB_PATH=/opt/humhub
-#  matrix:
-#    - HUMHUB_VERSION=master
-#    - HUMHUB_VERSION=v1.3-dev
+  matrix:
+    - HUMHUB_VERSION=master
+    - HUMHUB_VERSION=v1.3-dev
+
+matrix:
+  allow_failures:
+    - HUMHUB_VERSION=v1.3-dev
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 install:
-  - /bin/sh .travis/install-dependencies.sh
-  - /bin/sh .travis/setup-humhub.sh
+  - chmod +x .travis/*.sh
+  - .travis/install-dependencies.sh
+  - .travis/setup-humhub.sh
 
 script:
-  - php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &>/dev/null &
-  - sleep 5
-  - curl --fail --head http://127.0.0.1:8080/index-test.php
   - cd tests
   - php ${HUMHUB_PATH}/protected/vendor/bin/codecept build
   - php ${HUMHUB_PATH}/protected/vendor/bin/codecept run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: php
+sudo: enabled
+
+services:
+  - mysql
+
+php:
+  - '5.6'
+  - '7.0'
+  - '7.1'
+
+#env:
+  - HUMHUB_PATU=/opt/humhub
+#  - HUMHUB_VERSION=master
+#  - HUMHUB_VERSION=v1.3-dev
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+  - /bin/sh .travis/install-dependencies.sh
+  - /bin/sh .travis/setup-humhub.sh
+
+script:
+  - composer install --prefer-dist --no-interaction
+  - cd tests
+  - php ${HUMHUB_PATH}/protected/vendor/bin/codecept build
+  - php ${HUMHUB_PATH}/protected/vendor/bin/codecept run

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
   - .travis/setup-humhub.sh
 
 before_script:
+  - $HOME/chromedriver --url-base=/wd/hub &
   - php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &>/dev/null &
   - sleep 5 && curl --fail --head http://127.0.0.1:8080/index-test.php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ php:
   - '7.0'
   - '7.1'
 
-#env:
-  - HUMHUB_PATU=/opt/humhub
-#  - HUMHUB_VERSION=master
-#  - HUMHUB_VERSION=v1.3-dev
+env:
+  global:
+    - HUMHUB_PATU=/opt/humhub
+#  matrix:
+#    - HUMHUB_VERSION=master
+#    - HUMHUB_VERSION=v1.3-dev
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,16 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-install:
+before_install:
   - chmod +x .travis/*.sh
+
+install:
   - .travis/install-dependencies.sh
   - .travis/setup-humhub.sh
+
+before_script:
+  - php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &>/dev/null &
+  - sleep 5 && curl --fail --head http://127.0.0.1:8080/index-test.php
 
 script:
   - cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - HUMHUB_VERSION=v1.3-dev
 
 matrix:
+  fast_finish: true
   allow_failures:
     - HUMHUB_VERSION=v1.3-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: enabled
 services:
   - mysql
 
+addons:
+  chrome: stable
+
 git:
   depth: 3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: enabled
 services:
   - mysql
 
+git:
+  depth: 3
+
 php:
   - '5.6'
   - '7.0'
@@ -25,7 +28,6 @@ install:
   - /bin/sh .travis/setup-humhub.sh
 
 script:
-  - composer install --prefer-dist --no-interaction
   - cd tests
   - php ${HUMHUB_PATH}/protected/vendor/bin/codecept build
   - php ${HUMHUB_PATH}/protected/vendor/bin/codecept run

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -6,7 +6,7 @@ set -ev
 # Install chomedriver
 wget https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip
 unzip -d $HOME chromedriver_linux64.zip
-$HOME/chromedriver --url-base=/wd/hub --silent &
+$HOME/chromedriver --url-base=/wd/hub --log-level=warning &
 
 # Install composer package
 composer global require fxp/composer-asset-plugin

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -6,7 +6,7 @@ set -ev
 # Install chomedriver
 wget https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip
 unzip -d $HOME chromedriver_linux64.zip
-$HOME/chromedriver --url-base=/wd/hub --log-level=warning &
+$HOME/chromedriver --url-base=/wd/hub &
 
 # Install composer package
 composer global require fxp/composer-asset-plugin

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -5,7 +5,8 @@ set -ev
 
 # Install chomedriver
 curl -s -L -o chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip \
-    && unzip -o -d $HOME chromedriver_linux64.zip
+    && unzip -o -d $HOME chromedriver_linux64.zip \
+	&& chmod +x $HOME/chromedriver
 
 # Install composer package
 composer global require fxp/composer-asset-plugin

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -6,7 +6,7 @@ set -ev
 # Install chomedriver
 wget https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip
 unzip -d $HOME chromedriver_linux64.zip
-$HOME/chromedriver --url-base=/wd/hub &
+$HOME/chromedriver --url-base=/wd/hub --silent &
 
 # Install composer package
 composer global require fxp/composer-asset-plugin

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -4,8 +4,10 @@
 set -ev
 
 # Install chomedriver
-wget https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip
-unzip -d $HOME chromedriver_linux64.zip
+curl -s -L -o chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip \
+    && unzip -o -d $HOME chromedriver_linux64.zip
+
+# Start chomedriver
 $HOME/chromedriver --url-base=/wd/hub &
 
 # Install composer package

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env sh -ev
+#!/usr/bin/env sh
+
+# -e = exit when one command returns != 0, -v print each command before executing
+set -ev
 
 # Install chomedriver
 wget https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -7,8 +7,5 @@ set -ev
 curl -s -L -o chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip \
     && unzip -o -d $HOME chromedriver_linux64.zip
 
-# Start chomedriver
-$HOME/chromedriver --url-base=/wd/hub &
-
 # Install composer package
 composer global require fxp/composer-asset-plugin

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh -ev
+
+# Install chomedriver
+wget https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip
+unzip -d $HOME chromedriver_linux64.zip
+$HOME/chromedriver --url-base=/wd/hub &
+
+# Install composer package
+composer global require fxp/composer-asset-plugin

--- a/.travis/setup-humhub.sh
+++ b/.travis/setup-humhub.sh
@@ -9,11 +9,7 @@ mkdir ${HUMHUB_PATH}
 cd ${HUMHUB_PATH}
 
 git clone --branch master --depth 1 https://github.com/humhub/humhub.git .
-composer install --prefer-dist --no-interaction --quiet
-
-php -S 127.0.0.1:8080 &> /dev/null &
-sleep 5
-curl --fail --head http://127.0.0.1:8080/index-test.php
+composer install --prefer-dist --no-interaction
 
 cd ${HUMHUB_PATH}/protected/humhub/tests
 
@@ -24,5 +20,9 @@ mysql -e 'CREATE DATABASE humhub_test;'
 php codeception/bin/yii migrate/up --includeModuleMigrations=1 --interactive=0
 php codeception/bin/yii installer/auto
 php codeception/bin/yii search/rebuild
+
+php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &> /dev/null &
+sleep 5
+curl --fail --head http://127.0.0.1:8080/index-test.php
 
 php ${HUMHUB_PATH}/protected/vendor/bin/codecept build

--- a/.travis/setup-humhub.sh
+++ b/.travis/setup-humhub.sh
@@ -21,7 +21,7 @@ php codeception/bin/yii migrate/up --includeModuleMigrations=1 --interactive=0
 php codeception/bin/yii installer/auto
 php codeception/bin/yii search/rebuild
 
-php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &> /dev/null &
+php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &>/dev/null &
 sleep 5
 curl --fail --head http://127.0.0.1:8080/index-test.php
 

--- a/.travis/setup-humhub.sh
+++ b/.travis/setup-humhub.sh
@@ -25,6 +25,4 @@ php codeception/bin/yii migrate/up --includeModuleMigrations=1 --interactive=0
 php codeception/bin/yii installer/auto
 php codeception/bin/yii search/rebuild
 
-
-
 php ${HUMHUB_PATH}/protected/vendor/bin/codecept build

--- a/.travis/setup-humhub.sh
+++ b/.travis/setup-humhub.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh -ev
+
+old=$(pwd)
+
+mkdir ${HUMHUB_PATH}
+cd ${HUMHUB_PATH}
+
+git clone --branch master --depth 1 https://github.com/humhub/humhub.git .
+composer install --prefer-dist --no-interaction --quiet
+
+cd ${HUMHUB_PATH}/protected/humhub/tests
+
+sed -i -e "s|'installed' => true,|'installed' => true,\n\t'moduleAutoloadPaths' => ['$(dirname $old)']|g" config/common.php
+#cat config/common.php
+
+mysql -e 'CREATE DATABASE humhub_test;'
+php codeception/bin/yii migrate/up --includeModuleMigrations=1 --interactive=0
+php codeception/bin/yii installer/auto
+php codeception/bin/yii search/rebuild
+
+php ${HUMHUB_PATH}/protected/vendor/bin/codecept build

--- a/.travis/setup-humhub.sh
+++ b/.travis/setup-humhub.sh
@@ -21,8 +21,4 @@ php codeception/bin/yii migrate/up --includeModuleMigrations=1 --interactive=0
 php codeception/bin/yii installer/auto
 php codeception/bin/yii search/rebuild
 
-php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &>/dev/null &
-sleep 5
-curl --fail --head http://127.0.0.1:8080/index-test.php
-
 php ${HUMHUB_PATH}/protected/vendor/bin/codecept build

--- a/.travis/setup-humhub.sh
+++ b/.travis/setup-humhub.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env sh -ev
+#!/usr/bin/env sh
+
+# -e = exit when one command returns != 0, -v print each command before executing
+set -ev
 
 old=$(pwd)
 

--- a/.travis/setup-humhub.sh
+++ b/.travis/setup-humhub.sh
@@ -11,6 +11,10 @@ cd ${HUMHUB_PATH}
 git clone --branch master --depth 1 https://github.com/humhub/humhub.git .
 composer install --prefer-dist --no-interaction --quiet
 
+php -S 127.0.0.1:8080 &> /dev/null &
+sleep 5
+curl --fail --head http://127.0.0.1:8080/index-test.php
+
 cd ${HUMHUB_PATH}/protected/humhub/tests
 
 sed -i -e "s|'installed' => true,|'installed' => true,\n\t'moduleAutoloadPaths' => ['$(dirname $old)']|g" config/common.php
@@ -20,5 +24,7 @@ mysql -e 'CREATE DATABASE humhub_test;'
 php codeception/bin/yii migrate/up --includeModuleMigrations=1 --interactive=0
 php codeception/bin/yii installer/auto
 php codeception/bin/yii search/rebuild
+
+
 
 php ${HUMHUB_PATH}/protected/vendor/bin/codecept build

--- a/.travis/setup-humhub.sh
+++ b/.travis/setup-humhub.sh
@@ -8,7 +8,7 @@ old=$(pwd)
 mkdir ${HUMHUB_PATH}
 cd ${HUMHUB_PATH}
 
-git clone --branch master --depth 1 https://github.com/humhub/humhub.git .
+git clone --branch ${HUMHUB_VERSION} --depth 1 https://github.com/humhub/humhub.git .
 composer install --prefer-dist --no-interaction
 
 cd ${HUMHUB_PATH}/protected/humhub/tests
@@ -20,5 +20,9 @@ mysql -e 'CREATE DATABASE humhub_test;'
 php codeception/bin/yii migrate/up --includeModuleMigrations=1 --interactive=0
 php codeception/bin/yii installer/auto
 php codeception/bin/yii search/rebuild
+
+php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &>/dev/null &
+sleep 5
+curl --fail --head http://127.0.0.1:8080/index-test.php
 
 php ${HUMHUB_PATH}/protected/vendor/bin/codecept build

--- a/tests/codeception/acceptance.suite.yml
+++ b/tests/codeception/acceptance.suite.yml
@@ -10,15 +10,14 @@
 
 class_name: AcceptanceTester
 modules:
-    enabled:
-        #- PhpBrowser
-        - WebDriver
-        - tests\codeception\_support\WebHelper
-        - tests\codeception\_support\DynamicFixtureHelper
-    config:
-        PhpBrowser:
-            url: http://localhost:8080/
-        WebDriver:
-            url: http://localhost:8080/
-            browser: firefox
-            restart: true
+  enabled:
+    - WebDriver:
+        url: 'http://localhost:8080/'
+        window_size: false # disabled in ChromeDriver
+        port: 9515
+        browser: chrome
+        capabilities:
+          chromeOptions:
+            args: ['--headless', '--disable-gpu', '--no-sandbox']
+    - tests\codeception\_support\WebHelper
+    - tests\codeception\_support\DynamicFixtureHelper

--- a/tests/codeception/acceptance.suite.yml
+++ b/tests/codeception/acceptance.suite.yml
@@ -18,6 +18,6 @@ modules:
         browser: chrome
         capabilities:
           chromeOptions:
-            args: ['--headless', '--disable-gpu', '--no-sandbox']
+            args: ['--headless', '--disable-gpu', '--no-sandbox', '--window-size=1024,768']
     - tests\codeception\_support\WebHelper
     - tests\codeception\_support\DynamicFixtureHelper


### PR DESCRIPTION
Enable Travis-CI for Calendar-Module

- Build as matrix against PHP 5.6, 7.0, 7.1 and Humhub master / v1.3-dev
- Allow failure for v1.3-dev

Please enable Travis-CI for this repository before merge. Current build for my fork: https://travis-ci.org/danielkesselberg/humhub-modules-calendar