### PR TITLE
AbstractCalendarQuery:findForFilter keep time info

### DIFF
--- a/interfaces/AbstractCalendarQuery.php
+++ b/interfaces/AbstractCalendarQuery.php
@@ -138,7 +138,9 @@ abstract class AbstractCalendarQuery extends Component
     {
         return static::find()
             ->container($container)
-            ->from($start)->to($end)
+            ->to($end)
+            ->withTime()
+            ->from($start)
             ->filter($filters)
             ->limit($limit)->all();
     }


### PR DESCRIPTION
Proposed fix for #156

Keep time part of the $start argument in order to filter events that are yet to happen instead of including events that have completed.