### PR TITLE
Add a page title to the global calendar

### DIFF
--- a/controllers/GlobalController.php
+++ b/controllers/GlobalController.php
@@ -61,6 +61,7 @@ class GlobalController extends Controller
      */
     public function init()
     {
+        $this->appendPageTitle(Yii::t('CalendarModule.base', 'Calendar'));
         parent::init();
         $this->calendarService = $this->module->get(CalendarService::class);
     }


### PR DESCRIPTION
The global calendar did not have a page title set. Use "Calendar" (as
appropriately translated).