### PR TITLE
sync max_participants to parent entry #198

### DIFF
--- a/models/CalendarEntry.php
+++ b/models/CalendarEntry.php
@@ -821,6 +821,7 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, Recurrent
         $this->color = $root->color;
         $this->time_zone = $root->time_zone;
         $this->participation_mode = $root->participation_mode;
+        $this->max_participants = $root->max_participants;
         $this->all_day = $root->all_day;
         $this->allow_decline = $root->allow_decline;
         $this->allow_maybe = $root->allow_maybe;


### PR DESCRIPTION
#198 
in recurrence mode, `max_participant` did not sync to its parent and it was always empty, so it cause `checkMaxParticipant()` in `canRespond()` always return true.