### PR TITLE
Use Getter to access color property of calendar entry

### DIFF
--- a/widgets/views/wallEntry.php
+++ b/widgets/views/wallEntry.php
@@ -14,7 +14,7 @@ use humhub\widgets\Label;
 /* @var $stream boolean */
 /* @var $collapse boolean */
 
-$color = $calendarEntry->color ? $calendarEntry->color : $this->theme->variable('info');
+$color = $calendarEntry->getColor() ? $calendarEntry->getColor() : $this->theme->variable('info');
 ?>
 
 <div class="media event calendar-wall-entry" style="margin-top:20px;" data-action-component="calendar.CalendarEntry" data-calendar-entry="<?= $calendarEntry->id ?>">


### PR DESCRIPTION
Not a huge thing, but I modified the calendar module for an own installation where I changed the "getColor()" method and was surprised that the color was not used in the stream...